### PR TITLE
add the ability to set manual scroll depth

### DIFF
--- a/javascripts/sranalytics.js
+++ b/javascripts/sranalytics.js
@@ -5,10 +5,14 @@
     title: sranalytics.title,
     url: sranalytics.url,
     date: sranalytics.date,
+    authors: sranalytics.authors,
     channels: sranalytics.channels,
-    tags: sranalytics.tags,
-    authors: sranalytics.authors
+    tags: sranalytics.tags
   };
+
+  if(sranalytics.manual_scroll_depth === "1") {
+    __reach_config.manual_scroll_depth = true;
+  }
   var s = document.createElement('script');
   s.async = true;
   s.type = 'text/javascript';

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Plugin Name: SimpleReach Analytics
 Plugin URI: https://github.com/simplereach/sranalytics_wordpress
 Requires at least: 3.0
 Tested up to: 4.3.1
-Stable tag: 0.1.5
+Stable tag: 0.1.6
 
 SimpleReach Analytics finds trending articles and gives publishers deep insights into their social traffic.
 
@@ -15,6 +15,9 @@ SimpleReach Analytics finds trending articles and gives publishers deep insights
 3. Go to _Settings -> SimpleReach Analytics_ and enter your PID into the first field. Click _Save_.
 
 == Changelog ==
+
+= 0.1.6 =
+* Add the ability to set scroll depth to manual for infinite scroll sites 
 
 = 0.1.5 =
 * Remove deprecated author function and iframe feature

--- a/sranalytics.php
+++ b/sranalytics.php
@@ -45,6 +45,7 @@ function sranalytics_insert_js() {
 	$sranalytics_show_on_attachment_pages = get_option( 'sranalytics_show_on_attachment_pages' );
 	$sranalytics_show_everywhere = get_option( 'sranalytics_show_everywhere' );
 	$sranalytics_force_http = get_option( 'sranalytics_force_http' );
+	$sranalytics_manual_scroll_depth = get_option( 'sranalytics_manual_scroll_depth' );
 
 	// Try and check the validity of the PID
 	if ( empty( $sranalytics_pid) || 24 != strlen( $sranalytics_pid ) ) {
@@ -167,6 +168,9 @@ function sranalytics_insert_js() {
 		'authors' => array_map( 'esc_js', apply_filters( 'sranalytics_authors', $authors ) ),
 	);
 
+  if ($sranalytics_manual_scroll_depth) {
+    $javascript_array['manual_scroll_depth'] = true;
+  }
 	// Get the JS ready to go
 	if ($sranalytics_show_beacon) {
 		wp_register_script( 'sranalytics', plugins_url( 'javascripts/sranalytics.js', __FILE__) );

--- a/sranalytics_admin.php
+++ b/sranalytics_admin.php
@@ -5,7 +5,8 @@ $sranalytics_boolean_settings = array(
 	'sranalytics_show_on_wp_pages',
 	'sranalytics_show_on_attachment_pages',
 	'sranalytics_show_everywhere',
-	'sranalytics_force_http'
+	'sranalytics_force_http',
+	'sranalytics_manual_scroll_depth'
 );
 $message = '';
 if ( !empty( $_POST[ 'sranalytics_submitted' ] ) && current_user_can( 'manage_options' ) ) {
@@ -42,6 +43,7 @@ $sranalytics_show_everywhere = get_option( 'sranalytics_show_everywhere' );
 $sranalytics_show_on_wp_pages = get_option( 'sranalytics_show_on_wp_pages' );
 $sranalytics_show_on_attachment_pages = get_option( 'sranalytics_show_on_attachment_pages' );
 $sranalytics_force_http = get_option( 'sranalytics_force_http' );
+$sranalytics_manual_scroll_depth = get_option( 'sranalytics_manual_scroll_depth' );
 ?>
 
 <div class='overview'>
@@ -105,6 +107,11 @@ $sranalytics_force_http = get_option( 'sranalytics_force_http' );
 					<li>
 							<input type="checkbox" id='sranalytics_force_http' name="sranalytics_force_http" value="true"  <?php checked( $sranalytics_force_http, true ); ?>  />
 							<label for='sranalytics_force_http'><?php esc_html_e( 'Send urls as HTTP. If your site uses a combination of both HTTP and HTTPS, enable this option.', 'sranalytics' ); ?></label>
+					</li>
+
+					<li>
+							<input type="checkbox" id='sranalytics_manual_scroll_depth' name="sranalytics_manual_scroll_depth" value="true"  <?php checked( $sranalytics_manual_scroll_depth, true ); ?>  />
+							<label for='sranalytics_manual_scroll_depth'><?php esc_html_e( 'Make scroll depth tracking manual. This is reccomended for infinite scroll sites.', 'sranalytics' ); ?></label>
 					</li>
 					<li><input class='button-primary' type="submit" name="Submit" value="<?php esc_html_e( 'Save', 'sranalytics' ); ?>" /></li>
 			</ul>


### PR DESCRIPTION
Infinite scroll sites should have manual_scroll_depth set to false from the start. This allows them to do so.
